### PR TITLE
Front page updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,43 +249,12 @@
         <div class="topicLeftData-MainData">
           <p style="margin-left: 0px">
 
-            <em>Update Dec 14, 2021:</em>
-            <br><strong>MaterialX Library v1.38.3 has been released</strong>.
-            This release adds
-            refactored BSDF handling in shader generation enabling more flexible and efficient vertical layering,
-            optimized GLSL implementations for GGX specular,
-            a refactoring of the TextureBaker API,
-            versioning and customization support to MaterialX namespaces,
-            an inheritance structure for versions of Autodesk Standard Surface,
-            color transform methods to the Image class,
-            and initial support for FreeBSD and Xcode 13 as well as other updates and fixes.
-            Please see the
-            <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.3">MaterialX Version 1.38.3 release page</a>
-            on the MaterialX Github for further details, and visit the
-            <a href="https://github.com/AcademySoftwareFoundation/MaterialX">MaterialX GitHub repository</a>
-            to download the latest library source code, documentation and examples.
-            <br><br>
-
-            <em>Update Oct 7, 2021:</em>
-            <br><strong>MaterialX Library v1.38.2 has been released</strong>.
-            This release adds
-            improved accuracy of directional albedo computations for GGX specular and Imageworks sheen,
-            an initial shader translation graph from Autodesk Standard Surface to UsdPreviewSurface,
-            graph definitions for the MaterialX Lama node set,
-            an initial ESSL shader generator,
-            support for filename templates in texture baking,
-            initial support for GCC 11, and other fixes.
-            Please see the
-            <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.2">MaterialX Version 1.38.2 release page</a>
-            on the MaterialX Github for further details.
-            <br><br>
-
           <p style="margin-bottom: 0px; padding-bottom: 0px">
           </p>
 
           <!-- Page Content -------------------------------------------------------------------- -->
 
-          <h2><strong>MaterialX</strong></h2>
+          <h2><strong>MaterialX Overview</strong></h2>
           <p>
             <strong>MaterialX</strong> is an open standard for representing rich material and look-development
             content in computer graphics, enabling its platform-independent description and exchange across
@@ -307,13 +276,58 @@
             shading and processing nodes with a precise mechanism for functional extensibility.
           </p>
 
-          <p>The MaterialX library, now at release v1.38.3, is an <a href="https://github.com/AcademySoftwareFoundation/MaterialX" class="external-link" rel="nofollow">Open Source project</a> released under an <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/LICENSE" class="external-link" rel="nofollow">Apache License Version 2.0</a>.</p>
+          <p>The MaterialX library, now at release v1.38.4, is an <a href="https://github.com/AcademySoftwareFoundation/MaterialX" class="external-link" rel="nofollow">Open Source project</a> released under an <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/LICENSE" class="external-link" rel="nofollow">Apache License Version 2.0</a>.</p>
 
           <br>
           <h2><strong>Announcements</strong></h2>
           <p>
             <div>
               <p>
+
+                <em>Update Apr 6, 2022:</em>
+                <br><strong>MaterialX Library v1.38.4 has been released</strong>.
+                This release adds a
+                <a href="https://academysoftwarefoundation.github.io/MaterialX/">Web Viewer</a> example based on
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/javascript">MaterialX JavaScript</a>,
+                a graph for the <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/v1.38.4/libraries/bxdf/gltf_pbr.mtlx">glTF PBR</a>
+                shading model,
+                new Worley noise nodes,
+                and more.
+                Please see the
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.4">MaterialX Version 1.38.4 release page</a>
+                on the MaterialX Github for further details,
+                and visit the <a href="https://github.com/AcademySoftwareFoundation/MaterialX">MaterialX GitHub repository</a>
+                to download the latest library source code, documentation and examples.
+                <br><br>
+
+                <em>Update Dec 14, 2021:</em>
+                MaterialX Library v1.38.3 has been released.
+                This release adds
+                refactored BSDF handling in shader generation enabling more flexible and efficient vertical layering,
+                optimized GLSL implementations for GGX specular,
+                a refactoring of the TextureBaker API,
+                versioning and customization support to MaterialX namespaces,
+                an inheritance structure for versions of Autodesk Standard Surface,
+                color transform methods to the Image class,
+                and initial support for FreeBSD and Xcode 13 as well as other updates and fixes.
+                Please see the
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.3">MaterialX Version 1.38.3 release page</a>
+                on the MaterialX Github for further details.
+                <br><br>
+
+                <em>Update Oct 7, 2021:</em>
+                MaterialX Library v1.38.2 has been released.
+                This release adds
+                improved accuracy of directional albedo computations for GGX specular and Imageworks sheen,
+                an initial shader translation graph from Autodesk Standard Surface to UsdPreviewSurface,
+                graph definitions for the MaterialX Lama node set,
+                an initial ESSL shader generator,
+                support for filename templates in texture baking,
+                initial support for GCC 11, and other fixes.
+                Please see the
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.2">MaterialX Version 1.38.2 release page</a>
+                on the MaterialX Github for further details.
+                <br><br>
 
                 <em>Aug 10, 2021:</em>
                 The


### PR DESCRIPTION
- Add an announcement for MaterialX 1.38.4.
- Place the Overview just above Announcements.