### PR TITLE
Update specification links

### DIFF
--- a/Contributing.html
+++ b/Contributing.html
@@ -71,25 +71,15 @@
       </div>
       <ul>
         <li>
-          <a href="Specification.html">Specification</a>
+          <a href="Specification.html">MaterialX Specification</a>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.Spec.pdf">MaterialX Spec PDF (v1.38)</a>
+              <a href="Specification.html#CurrentSpec">Current Specification</a>
             </li>
           </ul>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.PBRSpec.pdf">Physically Based Shading Nodes</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="assets/MaterialX.v1.38.Supplement.pdf">Supplemental Notes PDF</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="Specification.html#RevisionHistory">Specification Revision History</a>
+              <a href="Specification.html#RevisionHistory">Revision History</a>
             </li>
           </ul>
         </li>
@@ -251,7 +241,7 @@
                 <a target="_blank" href="docs/api/index.html">Developer Guide</a>
               </li>
               <li class="">
-                <a target="_blank" href="Specification.html">Specification</a>
+                <a target="_blank" href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification">Specification</a>
               </li>
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>

--- a/DeveloperReference.html
+++ b/DeveloperReference.html
@@ -71,25 +71,15 @@
       </div>
       <ul>
         <li>
-          <a href="Specification.html">Specification</a>
+          <a href="Specification.html">MaterialX Specification</a>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.Spec.pdf">MaterialX Spec PDF (v1.38)</a>
+              <a href="Specification.html#CurrentSpec">Current Specification</a>
             </li>
           </ul>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.PBRSpec.pdf">Physically Based Shading Nodes</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="assets/MaterialX.v1.38.Supplement.pdf">Supplemental Notes PDF</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="Specification.html#RevisionHistory">Specification Revision History</a>
+              <a href="Specification.html#RevisionHistory">Revision History</a>
             </li>
           </ul>
         </li>
@@ -251,7 +241,7 @@
                 <a target="_blank" href="docs/api/index.html">Developer Guide</a>
               </li>
               <li class="">
-                <a target="_blank" href="Specification.html">Specification</a>
+                <a target="_blank" href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification">Specification</a>
               </li>
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>

--- a/Specification.html
+++ b/Specification.html
@@ -71,25 +71,15 @@
       </div>
       <ul>
         <li>
-          <a href="Specification.html">Specification</a>
+          <a href="Specification.html">MaterialX Specification</a>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.Spec.pdf">MaterialX Spec PDF (v1.38)</a>
+              <a href="Specification.html#CurrentSpec">Current Specification</a>
             </li>
           </ul>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.PBRSpec.pdf">Physically Based Shading Nodes</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="assets/MaterialX.v1.38.Supplement.pdf">Supplemental Notes PDF</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="Specification.html#RevisionHistory">Specification Revision History</a>
+              <a href="Specification.html#RevisionHistory">Revision History</a>
             </li>
           </ul>
         </li>
@@ -251,7 +241,7 @@
                 <a target="_blank" href="docs/api/index.html">Developer Guide</a>
               </li>
               <li class="">
-                <a target="_blank" href="Specification.html">Specification</a>
+                <a target="_blank" href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification">Specification</a>
               </li>
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>
@@ -277,33 +267,48 @@
 
           <!-- Page Content -------------------------------------------------------------------- -->
 
-          <h2 id="SpecDownload"><strong>Current Spec: v1.38</strong></h2>
-          <br>
-          <a target="_blank" class="blueButton" style="width:250px; font-size:14px; float:left; margin-left:20px" href="assets/MaterialX.v1.38.Spec.pdf">Download the Specification</a>
-          <br>&nbsp;<br>
-          <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<em>(Mar 1, 2021)</em></p>
+          <h2 id="CurrentSpec"><strong>Current Specification (v1.39)</strong></h2>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.PBRSpec.pdf">MaterialX Physically Based Shading Nodes v1.38</a>
+              <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification">Overview</a>
             </li>
-            <li>
-              <a href="assets/MaterialX.v1.38.Supplement.pdf">MaterialX Supplemental Notes v1.38</a>
-            </li>
-            <li>
-              <a href="assets/MaterialX.v1.38.Changelist.pdf">Changes since v1.37REV2</a>
-            </li>
+            <ul>
+              <li>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md">MaterialX Standard</a>
+              </li>
+              <li>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.PBRSpec.md">Physically Based Shading Nodes</a>
+              </li>
+              <li>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.NPRSpec.md">NPR Shading Nodes</a>
+              </li>
+              <li>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.GeomExts.md">Geometry Extensions</a>
+              </li>
+              <li>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Supplement.md">Supplemental Notes</a>
+              </li>
+            </ul>
           </ul>
 
-          <br>
           <h2 id="RevisionHistory"><strong>Revision History</strong></h2>
           <ul>
             <li>
-              v1.37REV2
+              v1.38
               <ul>
-                <li><a href="assets/MaterialX.v1.37REV2.Spec.pdf">Specification v1.37 REV2 (Jul 21, 2018)</a></li>
-                <li><a href="assets/MaterialX.v1.37REV2.PBRSpec.pdf">Physically Based Shading Nodes v1.37</a></li>
-                <li><a href="assets/MaterialX.v1.37REV2.Supplement.pdf">Supplemental Notes v1.37</a></li>
-                <li><a href="assets/MaterialX.v1.37REV2.Changelist.pdf">Changes since v1.36 (and 1.37Rev1)</a></li>
+                <li><a href="assets/MaterialX.v1.38.Spec.pdf">Specification v1.38 (Mar 1, 2021)</a></li>
+                <li><a href="assets/MaterialX.v1.38.PBRSpec.pdf">Physically Based Shading Nodes v1.38</a></li>
+                <li><a href="assets/MaterialX.v1.38.Supplement.pdf">Supplemental Notes v1.38</a></li>
+                <li><a href="assets/MaterialX.v1.38.Changelist.pdf">Changes since v1.37</a></li>
+              </ul>
+            </li>
+            <li>
+              v1.37
+              <ul>
+                <li><a href="assets/MaterialX.v1.37REV2.Spec.pdf">Specification v1.37 Revision 2 (Jan 19, 2020)</a></li>
+                <li><a href="assets/MaterialX.v1.37REV2.PBRSpec.pdf">Physically Based Shading Nodes v1.37 Revision 2</a></li>
+                <li><a href="assets/MaterialX.v1.37REV2.Supplement.pdf">Supplemental Notes v1.37 Revision 2</a></li>
+                <li><a href="assets/MaterialX.v1.37REV2.Changelist.pdf">Changes since v1.36</a></li>
               </ul>
             </li>
             <li>

--- a/ThirdPartySupport.html
+++ b/ThirdPartySupport.html
@@ -71,25 +71,15 @@
       </div>
       <ul>
         <li>
-          <a href="Specification.html">Specification</a>
+          <a href="Specification.html">MaterialX Specification</a>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.Spec.pdf">MaterialX Spec PDF (v1.38)</a>
+              <a href="Specification.html#CurrentSpec">Current Specification</a>
             </li>
           </ul>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.PBRSpec.pdf">Physically Based Shading Nodes</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="assets/MaterialX.v1.38.Supplement.pdf">Supplemental Notes PDF</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="Specification.html#RevisionHistory">Specification Revision History</a>
+              <a href="Specification.html#RevisionHistory">Revision History</a>
             </li>
           </ul>
         </li>
@@ -251,7 +241,7 @@
                 <a target="_blank" href="docs/api/index.html">Developer Guide</a>
               </li>
               <li class="">
-                <a target="_blank" href="Specification.html">Specification</a>
+                <a target="_blank" href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification">Specification</a>
               </li>
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>

--- a/Tools.html
+++ b/Tools.html
@@ -71,25 +71,15 @@
       </div>
       <ul>
         <li>
-          <a href="Specification.html">Specification</a>
+          <a href="Specification.html">MaterialX Specification</a>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.Spec.pdf">MaterialX Spec PDF (v1.38)</a>
+              <a href="Specification.html#CurrentSpec">Current Specification</a>
             </li>
           </ul>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.PBRSpec.pdf">Physically Based Shading Nodes</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="assets/MaterialX.v1.38.Supplement.pdf">Supplemental Notes PDF</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="Specification.html#RevisionHistory">Specification Revision History</a>
+              <a href="Specification.html#RevisionHistory">Revision History</a>
             </li>
           </ul>
         </li>
@@ -251,7 +241,7 @@
                 <a target="_blank" href="docs/api/index.html">Developer Guide</a>
               </li>
               <li class="">
-                <a target="_blank" href="Specification.html">Specification</a>
+                <a target="_blank" href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification">Specification</a>
               </li>
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>

--- a/index.html
+++ b/index.html
@@ -71,25 +71,15 @@
       </div>
       <ul>
         <li>
-          <a href="Specification.html">Specification</a>
+          <a href="Specification.html">MaterialX Specification</a>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.Spec.pdf">MaterialX Spec PDF (v1.38)</a>
+              <a href="Specification.html#CurrentSpec">Current Specification</a>
             </li>
           </ul>
           <ul>
             <li>
-              <a href="assets/MaterialX.v1.38.PBRSpec.pdf">Physically Based Shading Nodes</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="assets/MaterialX.v1.38.Supplement.pdf">Supplemental Notes PDF</a>
-            </li>
-          </ul>
-          <ul>
-            <li>
-              <a href="Specification.html#RevisionHistory">Specification Revision History</a>
+              <a href="Specification.html#RevisionHistory">Revision History</a>
             </li>
           </ul>
         </li>
@@ -251,7 +241,7 @@
                 <a target="_blank" href="docs/api/index.html">Developer Guide</a>
               </li>
               <li class="">
-                <a target="_blank" href="Specification.html">Specification</a>
+                <a target="_blank" href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification">Specification</a>
               </li>
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>


### PR DESCRIPTION
This changelist updates specification links to point to the latest 1.39 documentation on GitHub, moving 1.38 links to the revision history.