### PR TITLE
Add MaterialX 1.38.10 announcement

### DIFF
--- a/Specification.html
+++ b/Specification.html
@@ -274,7 +274,7 @@
             </li>
             <ul>
               <li>
-                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md">MaterialX Standard</a>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md">Core Specification</a>
               </li>
               <li>
                 <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.PBRSpec.md">Physically Based Shading Nodes</a>

--- a/index.html
+++ b/index.html
@@ -305,7 +305,8 @@
 
                 <em>Update April 12th, 2024:</em>
                 <br><strong>MaterialX Library v1.38.10 has been released</strong>.
-                This is primarily a patch build to improve MaterialX integrations in USD, with the one new feature being environment light intensity controls in generated GLSL shaders.
+                This is primarily a patch build to improve MaterialX integrations in USD,
+                with the one new feature being environment light intensity controls in generated GLSL shaders.
                 Please see the
                 <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.10">MaterialX Version 1.38.10 release page</a>
                 on the MaterialX Github for further details,

--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
             shading and processing nodes with a precise mechanism for functional extensibility.
           </p>
 
-          <p>The MaterialX library, now at release v1.38.9, is an <a href="https://github.com/AcademySoftwareFoundation/MaterialX" class="external-link" rel="nofollow">Open Source project</a> released under an <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/LICENSE" class="external-link" rel="nofollow">Apache License Version 2.0</a>.</p>
+          <p>The MaterialX library, now at release v1.38.10, is an <a href="https://github.com/AcademySoftwareFoundation/MaterialX" class="external-link" rel="nofollow">Open Source project</a> released under an <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/LICENSE" class="external-link" rel="nofollow">Apache License Version 2.0</a>.</p>
 
           <br>
           <h2><strong>Announcements</strong></h2>
@@ -303,16 +303,24 @@
             <div>
               <p>
 
+                <em>Update April 12th, 2024:</em>
+                <br><strong>MaterialX Library v1.38.10 has been released</strong>.
+                This is primarily a patch build to improve MaterialX integrations in USD, with the one new feature being environment light intensity controls in generated GLSL shaders.
+                Please see the
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.10">MaterialX Version 1.38.10 release page</a>
+                on the MaterialX Github for further details,
+                and visit the <a href="https://github.com/AcademySoftwareFoundation/MaterialX">MaterialX GitHub repository</a>
+                to download the latest library source code, documentation and examples.
+                <br><br>
+
                 <em>Update February 26th, 2024:</em>
-                <br><strong>MaterialX Library v1.38.9 has been released</strong>.
+                MaterialX Library v1.38.9 has been released.
                 This version adds support for environment prefiltering on the GPU,
                 integrates improvements to the MaterialX Graph Editor and MaterialX Web Viewer from the ASWF Dev Days community,
                 and introduces the first non-photorealistic rendering node library to MaterialX.
                 Please see the
                 <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.38.9">MaterialX Version 1.38.9 release page</a>
-                on the MaterialX Github for further details,
-                and visit the <a href="https://github.com/AcademySoftwareFoundation/MaterialX">MaterialX GitHub repository</a>
-                to download the latest library source code, documentation and examples.
+                on the MaterialX Github for further details.
                 <br><br>
 
                 <em>Update September 8, 2023:</em>


### PR DESCRIPTION
This changelist adds an announcement for MaterialX 1.38.10, and makes a minor edit to the text of the core specification link.