### PR TITLE
Add link to MaterialX Proposals

### DIFF
--- a/Specification.html
+++ b/Specification.html
@@ -288,6 +288,9 @@
               <li>
                 <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Supplement.md">Supplemental Notes</a>
               </li>
+              <li>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Proposals.md">Proposals</a>
+              </li>
             </ul>
           </ul>
 


### PR DESCRIPTION
This changelist adds a link to the new MaterialX Proposals document in the specification folder.