### PR TITLE
Add identity attributes for Mastodon

### DIFF
--- a/Contributing.html
+++ b/Contributing.html
@@ -246,7 +246,7 @@
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>
               </li>
-              <a class="iconButton" href="https://fosstodon.org/@MaterialX" style="float:right">
+              <a class="iconButton" href="https://fosstodon.org/@MaterialX" rel="me" style="float:right">
                 <img src="images/MastodonLogo.svg" width=20 height=20>
               </a>
             </ul>

--- a/DeveloperReference.html
+++ b/DeveloperReference.html
@@ -246,7 +246,7 @@
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>
               </li>
-              <a class="iconButton" href="https://fosstodon.org/@MaterialX" style="float:right">
+              <a class="iconButton" href="https://fosstodon.org/@MaterialX" rel="me" style="float:right">
                 <img src="images/MastodonLogo.svg" width=20 height=20>
               </a>
             </ul>

--- a/Specification.html
+++ b/Specification.html
@@ -246,7 +246,7 @@
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>
               </li>
-              <a class="iconButton" href="https://fosstodon.org/@MaterialX" style="float:right">
+              <a class="iconButton" href="https://fosstodon.org/@MaterialX" rel="me" style="float:right">
                 <img src="images/MastodonLogo.svg" width=20 height=20>
               </a>
             </ul>

--- a/ThirdPartySupport.html
+++ b/ThirdPartySupport.html
@@ -246,7 +246,7 @@
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>
               </li>
-              <a class="iconButton" href="https://fosstodon.org/@MaterialX" style="float:right">
+              <a class="iconButton" href="https://fosstodon.org/@MaterialX" rel="me" style="float:right">
                 <img src="images/MastodonLogo.svg" width=20 height=20>
               </a>
             </ul>

--- a/Tools.html
+++ b/Tools.html
@@ -246,7 +246,7 @@
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>
               </li>
-              <a class="iconButton" href="https://fosstodon.org/@MaterialX" style="float:right">
+              <a class="iconButton" href="https://fosstodon.org/@MaterialX" rel="me" style="float:right">
                 <img src="images/MastodonLogo.svg" width=20 height=20>
               </a>
             </ul>

--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
               <li class="">
                 <a class="blueButton" style="font-size:14px" href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub</a>
               </li>
-              <a class="iconButton" href="https://fosstodon.org/@MaterialX" style="float:right">
+              <a class="iconButton" href="https://fosstodon.org/@MaterialX" rel="me" style="float:right">
                 <img src="images/MastodonLogo.svg" width=20 height=20>
               </a>
             </ul>


### PR DESCRIPTION
This changelist adds identity attributes for the MaterialX account on Mastodon.