### PR TITLE
Add link to Standard Nodes

### DIFF
--- a/Specification.html
+++ b/Specification.html
@@ -277,6 +277,9 @@
                 <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md">Core Specification</a>
               </li>
               <li>
+                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.StandardNodes.md">Standard Nodes</a>
+              </li>
+              <li>
                 <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.PBRSpec.md">Physically Based Shading Nodes</a>
               </li>
               <li>


### PR DESCRIPTION
This changelist adds a link to the new Standard Nodes document of the MaterialX specification.