### PR TITLE
Simplify announcements and events

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,6 @@
           <p>
             <div>
               <p>
-
                 <em>Update March 7th, 2025:</em>
                 <br><strong>MaterialX Library v1.39.3 has been released</strong>.
                 This version improves the alignment between MaterialX and OpenUSD,
@@ -525,67 +524,13 @@
                 viewer and other updates.  Please see the
                 <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.37.1">MaterialX Version 1.37.1 release page</a>
                 on the MaterialX Github for further details.
-                <br><br>
-
-                <em>Jan 19, 2020:</em>
-                An updated MaterialX Specification version 1.37REV2 has been
-                released.  MaterialX 1.37 supports a new set of PBR Shading nodes,
-                new operator nodes, USD-compatible geometric properties, look groups and
-                much more.  With REV2, support for units on specified parameter values
-                was added, as well as additional cleanup and clarifications.
-                <br><br>
-
-                <em>July 17, 2019:</em>
-                MaterialX Specification version 1.37 has been released,
-                supporting a new set of PBR Shading nodes, new operator nodes,
-                USD-compatible geometric properties, look groups and much more.
-                <br><br>
-
-                <em>May 3, 2019:</em>
-                A first version of the MaterialXRender and MaterialXView libraries,
-                ShaderGen GLSL/OSL shader generation, and the cross-platform (Windows, Linux,
-                Mac OS X) standalone
-                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/DeveloperGuide/Viewer.md">MaterialX Viewer</a>
-                have been released as part of the MaterialX distribution.
-                <br><br>
-
-                <em>July 23, 2018:</em>
-                MaterialX v1.36
-                specification and codebase have been released, supporting an extended set
-                of math operators, node versioning, node definition inheritance, USD-compatible
-                collections, and much more.
-                See the <a target="_blank" href="Specification.html">Specification</a> page
-                for PDFs of the Specification, Supplemental Notes and changelist, and our
-                <a href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub repository</a>
-                to download the MaterialX 1.36 Library source code, documentation and examples.
-                <br><br>
-
-                <em>Dec 20, 2017</em> -
-                <a href="https://github.com/AcademySoftwareFoundation/MaterialX">MaterialX library release v1.35.4</a>
-                is now out, with a new high-level Material API, support for multi-output nodes, and example interfaces for the Disney BRDF, Disney BSDF and alSurface shaders.
-                Full details available on the
-                <a href="https://github.com/AcademySoftwareFoundation/MaterialX/releases">MaterialX Releases page</a>.
-                <br><br>
-
-                <em>July 11, 2017</em> - MaterialX is now Open Source!
-                &nbsp; (<a href="assets/MaterialX_Announce.2017.07.11.pdf">Announcement PDF</a>)
-                <br>
-                See our
-                <a href="https://github.com/AcademySoftwareFoundation/MaterialX">GitHub repository</a> and
-                <a href="docs/api/index.html">Developer Guide</a> for more details.
-                <br><br>
-
-                <em>July 22, 2016</em> - The MaterialX specification was publicly released on
-                <a href="http://www.materialx.org/">materialx.org</a>.
               </p>
             </div>
           </p>
 
-          <br>
           <h2 id="Events"><strong>Events</strong></h2>
           <p>
             <div>
-
               <p>
                 <em>August 5, 2025 - </em>
                 <a href="https://www.aswf.io/">Academy Software Foundation</a>
@@ -663,8 +608,6 @@
                 <br>
                 <strong>MaterialX: An Open Standard for Network-Based CG Object Looks</strong>
                 <br>
-                "Discussion of MaterialX, an open standard for the transfer of rich material and lookdev content between different DCC tools and renderers."
-                <br>
                 (<a href="assets/MaterialX_Sig2020_BOF_slides.pdf">Slide Deck PDF</a>)
                 <br><br>
 
@@ -672,64 +615,10 @@
                 <a href="https://www.aswf.io/">Academy Software Foundation</a>
                 Open Source Days 2020 Session
                 <br>
-                "<a href="https://opensourcedays2020.sched.com/event/dbb5/new-developments-in-materialx?iframe=yes&w=100%&sidebar=yes&bg=no"><strong>New Developments in MaterialX</strong></a>"
+                <a href="https://opensourcedays2020.sched.com/event/dbb5/new-developments-in-materialx?iframe=yes&w=100%&sidebar=yes&bg=no"><strong>New Developments in MaterialX</strong></a>
                 <br>
                 (<a href="https://www.youtube.com/watch?v=kvYHVSkbaoM">Presentation Video</a>)
                 <br><br>
-
-                <em>July 30, 2019 - </em>
-                <a href="https://s2019.siggraph.org/">Siggraph 2019</a>
-                Birds-of-a-Feather Session
-                <br>
-                <strong>MaterialX: An Open Standard for Network-Based CG Object Looks</strong>
-                <br>
-                "Discussion of MaterialX, an open standard for the transfer of rich material and lookdev content between different DCC tools and renderers."
-                <br>
-                (<a href="assets/MaterialX_Sig2019_BOF_slides.pdf">Slide Deck PDF</a>)
-                &nbsp; (<a href="https://youtu.be/pQ11A9i0-no">Session Video</a>)
-                <br><br>
-
-                <em>July 31, 2019 - </em>
-                <a href="https://s2019.siggraph.org/">Siggraph 2019</a>
-                Autodesk Exhibitor Session
-                <br>
-                <strong>Open Source Support at Autodesk: MaterialX</strong>
-                <br>
-                "Open source projects play an increasingly critical role in the creation of Film and TV content. We’ll start with an update on open source support at Autodesk, then deep-dive into our work on USD, including collaboration with tech partners and creative studios."
-                <br>
-                (<a href="assets/Sig2019_ADSK_MaterialX_Vision_Series.pdf">Slide Deck PDF</a>)
-                &nbsp; (<a href="https://area.autodesk.com/blogs/thebuzz/open-source-at-autodesk-materialx/">Session Video</a>)
-                <br><br>
-
-                <em>August 13, 2018 - </em>
-                <a href="https://s2018.siggraph.org/">Siggraph 2018</a>
-                Birds-of-a-Feather Meeting
-                <br>
-                <strong>MaterialX: An Open Standard for Network-Based CG Object Looks</strong>
-                <br>
-                "Discussion of MaterialX, an open standard for the transfer of rich material and lookdev content between different DCC tools and renderers."
-                <br>
-                (<a href="assets/MaterialX_Sig2018_BOF_slides.pdf">Slide Deck PDF</a>)
-                <br><br>
-
-                <em>July 31, 2017 - </em>
-                <a href="https://s2017.siggraph.org/">Siggraph 2017</a>
-                Birds-of-a-Feather Meeting
-                <br>
-                <strong>MaterialX: An Open Standard for Network-Based CG Object Looks</strong>
-                <br>
-                "A discussion of MaterialX, an open standard for the transfer of rich material and lookdev content between different DCC tools and renderers."
-                <br>
-                (<a href="assets/MaterialX%20Sig2017%20BOF%20Slides.pdf">Slide Deck PDF</a>)
-                <br><br>
-
-                <em>July 27, 2016 - </em>
-                <a href="https://s2016.siggraph.org/">Siggraph 2016</a>
-                Birds-of-a-Feather Meeting
-                <br>
-                <strong>MaterialX: An Open Standard for Network-Based CG Object Looks</strong>
-                <br>
-                "Presentation and discussion of MaterialX, an open standard for transfer of rich material and look-development content between different DCC tools and renderers, with recent feature-film production examples."
               </p>
             </div>
           </p>


### PR DESCRIPTION
This changelist simplifies our lists of announcements and events, which have become a bit unwieldy to read through, focusing on entries that have occurred since 2020.