### PR TITLE
Update third-party support

### DIFF
--- a/ThirdPartySupport.html
+++ b/ThirdPartySupport.html
@@ -69,7 +69,7 @@
 
           <h2 id="VRED"><strong>Autodesk VRED</strong></h2>
           <p>
-            Autodesk supports import of MaterialX documents in <a href="https://help.autodesk.com/view/VREDPRODUCTS/2024/ENU/?guid=VRED_Truelight_Materials_MaterialX">VRED 2024 and beyond</a>, providing access to external libraries of MaterialX content in the application.
+            Autodesk supports import of MaterialX documents in <a href="https://help.autodesk.com/view/VREDPRODUCTS/2025/ENU/?guid=VRED_Truelight_Materials_MaterialX">VRED 2024 and beyond</a>, providing access to external libraries of MaterialX content in the application.
           </p>
 
           <h2 id="Apple"><strong>Apple VisionOS</strong></h2>
@@ -92,12 +92,12 @@
           <p>
             NVIDIA supports MaterialX in <a href="https://docs.omniverse.nvidia.com/kit/docs/omni.materialx.libs/latest/Overview.html">Omniverse Kit 1.0.1 and beyond</a>, allowing MaterialX documents to be imported and rendered through MDL shader generation.
             <br><br>
-            Additional details on the roadmap for MaterialX in Omniverse may be found on the <a href="https://developer.nvidia.com/blog/unlock-seamless-material-interchange-for-virtual-worlds-with-openusd-materialx-and-openpbr/">NVIDIA developer site</a> and in the slides from the MaterialX Virtual Town Hall at <a href="https://materialx.org/assets/ASWF_OSD2024_MaterialX_Final.pdf">ASWF Open Source Days 2024</a>.
+            Additional details on the roadmap for MaterialX in Omniverse may be found on the <a href="https://developer.nvidia.com/blog/unlock-seamless-material-interchange-for-virtual-worlds-with-openusd-materialx-and-openpbr/">NVIDIA developer site</a> and in the slides from the MaterialX Virtual Town Hall at <a href="https://materialx.org/assets/ASWF_OSD2025_MaterialX_Final.pdf">ASWF Open Source Days 2025</a>.
           </p>
 
           <h2 id="Arnold"><strong>Autodesk Arnold</strong></h2>
           <p>
-            Autodesk supports MaterialX in <a href="https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_user_guide_ac_operators_ac_operators_materialx_html">Arnold 5 and beyond</a>, allowing MaterialX documents to be referenced and rendered through a custom MaterialX operator.
+            Autodesk supports MaterialX in <a href="https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_user_guide_ac_operators_ac_operators_materialx_html">Arnold 5.1 and beyond</a>, allowing MaterialX documents to be referenced and rendered through a custom MaterialX operator.
             <br><br>
             MaterialX content can be exported from Arnold implementations in tools such as <a href="https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_maya_lookdev_am_Working_With_MaterialX_html">Maya</a> and <a href="https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_cinema_4d_ci_Utilities_ci_Material_Export_html">Cinema 4D</a>.
             <br><br>
@@ -108,7 +108,7 @@
           <p>
             Pixar supports MaterialX in <a href="https://rmanwiki-26.pixar.com/space/REN26/19662341/MaterialX">RenderMan 24 and beyond</a>, rendering MaterialX pattern nodes through USD HdPrman, and rendering Physically Based Shading features through a custom implementation of the <a href="https://rmanwiki-26.pixar.com/space/REN26/19661457/MaterialX+Lama">MaterialX Lama</a> nodes.
             <br><br>
-            Additional details on MaterialX Lama may be found in this <a href="https://www.youtube.com/playlist?list=PLBozb72i61ywUiXPHA3nUgD9_9_b3phGW">tutorial series</a> from Pixar.
+            Early details on MaterialX BSDF support in RenderMan XPU may be found in the slides from the MaterialX Virtual Town Hall at <a href="https://materialx.org/assets/ASWF_OSD2025_MaterialX_Final.pdf">ASWF Open Source Days 2025</a>.
           </p>
 
           <h2 id="V-Ray"><strong>Chaos V-Ray</strong></h2>


### PR DESCRIPTION
- Add a link to the RenderMan XPU talk from the MaterialX Virtual Town Hall.
- Clarify the Arnold version in which MaterialX support was first introduced.
- Update links from 2024 to 2025 as needed.